### PR TITLE
Restrict gcloud docker auth cred helper to eu.gcr.io

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
         run: |
           echo "$GCLOUD_AUTH" | base64 --decode > ${HOME}/gcloud.json
           gcloud auth activate-service-account --key-file=${HOME}/gcloud.json
-          gcloud auth configure-docker
+          gcloud auth configure-docker eu.gcr.io
           rm ${HOME}/gcloud.json
 
       - name: Deploy to GCR


### PR DESCRIPTION
Should prevent:
```
WARNING: A long list of credential helpers may cause delays running 'docker build'. We recommend passing the registry name to configure only the registry you are using.
```